### PR TITLE
Add ChunkDataset checkpoint support

### DIFF
--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -1472,6 +1472,7 @@ TEST(DataLoaderTest, StatefulDatasetWithNoWorkers) {
     void reset() override {
       counter = 0;
     }
+    void save(const std::string& save_file_name) override{};
     int counter = 0;
   };
 
@@ -1508,6 +1509,8 @@ TEST(DataLoaderTest, StatefulDatasetWithManyWorkers) {
     void reset() override {
       counter = 0;
     }
+    void save(const std::string& save_file_name) override{};
+
     int counter = 0;
     std::mutex mutex;
   };
@@ -1545,6 +1548,7 @@ TEST(DataLoaderTest, StatefulDatasetWithMap) {
     void reset() override {
       counter = 0;
     }
+    void save(const std::string& save_file_name) override{};
     int counter = 0;
   };
 
@@ -1592,6 +1596,7 @@ TEST(DataLoaderTest, StatefulDatasetWithCollate) {
     void reset() override {
       counter = 0;
     }
+    void save(const std::string& save_file_name) override{};
     int counter = 0;
   };
 
@@ -1917,12 +1922,12 @@ TEST(DataLoaderTest, ChunkDatasetSave) {
 
   DummyTestChunkDataReader data_reader;
 
-  // tested save_intevals
-  const size_t save_intevals[] = {1, 2};
+  // tested save_intervals
+  const size_t save_intervals[] = {1, 2};
 
   using datasets::ChunkDatasetOptions;
 
-  for (auto save_inteval : save_intevals) {
+  for (auto save_interval : save_intervals) {
     auto tempfile = c10::make_tempfile();
 
     datasets::SharedBatchDataset<datasets::ChunkDataset<
@@ -1950,7 +1955,7 @@ TEST(DataLoaderTest, ChunkDatasetSave) {
       for (auto iterator = data_loader->begin(); iterator != data_loader->end();
            ++iterator, ++iteration_count) {
              
-        if ((iteration_count + 1) % save_inteval == 0) {
+        if ((iteration_count + 1) % save_interval == 0) {
           dataset->save(tempfile.name);
 
           samplers::SequentialSampler new_sampler(0);
@@ -2005,7 +2010,7 @@ TEST(DataLoaderTest, ChunkDatasetResume) {
   const size_t prefetch_count = 1;
   const size_t batch_size = 10;
   const size_t dataloader_worker_count = 0;
-  const size_t save_inteval = 2;
+  const size_t save_interval = 2;
 
   DummyChunkDataReader data_reader;
   samplers::SequentialSampler sampler(0);

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -1971,9 +1971,9 @@ TEST(DataLoaderTest, ChunkDatasetSave) {
           // output, hence verify the logic. In this test, the cache size is
           // configured to be the same as chunk size and batch size. So the
           // chunk data is written to the cache one by one. Only the current
-          // batch is retrieved, the next chunk is writen. Now after the first
-          // batch is retrieved, when we tries to retrive the second batch,
-          // there are three possible scenarios for the writer thread:
+          // batch is retrieved, the next chunk is writen. Now in iteration 0,
+          // after the first batch is retrieved, when we save the dataset
+          // statues, there are three possible scenarios for the writer thread:
           // 1. it hasn't started loading the next chunk data yet, so the
           // sequential sampler index is still 0;
           // 2. it started to load the second chunk, so the sequencial sampler
@@ -1990,14 +1990,14 @@ TEST(DataLoaderTest, ChunkDatasetSave) {
           // sequential sampler, it already moves to the second index. So when
           // we save it, it is the second index we save. As a result,
           // we need to advance the window by one. Now we have the expected
-          // window of [0, 3].
+          // window of [1, 3].
           // This analysis applies to all scenarios. So extend it to a more
           // general case: the expected saved index should falling into the
-          // range of [iteration - 1, iteration + 2], which is the validation
+          // range of [iteration, iteration + 3], which is the validation
           // below.
           ASSERT_TRUE(
-              new_sampler.index() >= std::max(0, iteration_count - 1) &&
-              new_sampler.index() <= iteration_count + 2);
+              new_sampler.index() >= iteration_count + 1 &&
+              new_sampler.index() <= iteration_count + 3);
         }
       }
     }

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -1925,7 +1925,7 @@ TEST(DataLoaderTest, ChunkDatasetSaveOption) {
     using BatchType = datasets::ChunkDataReader<int>::ChunkType;
 
     BatchType read_chunk(size_t chunk_index) override {
-      return batch_data;
+      return batch_data_;
     }
 
     size_t chunk_count() override {
@@ -1933,7 +1933,7 @@ TEST(DataLoaderTest, ChunkDatasetSaveOption) {
     };
 
     void reset() override{};
-    BatchType batch_data = BatchType(chunk_size, 0);
+    BatchType batch_data_ = BatchType(chunk_size, 0);
   };
 
   const size_t prefetch_count = 1;
@@ -1966,7 +1966,7 @@ TEST(DataLoaderTest, ChunkDatasetSaveOption) {
             ChunkDatasetOptions(
                 prefetch_count,
                 batch_size,
-                chunk_size/*cache size*/,
+                chunk_size /*cache size*/,
                 ChunkDatasetOptions::CheckpointOption::Save,
                 tempfile.name,
                 save_inteval));
@@ -1994,8 +1994,8 @@ TEST(DataLoaderTest, ChunkDatasetSaveOption) {
           // configured to be the same as chunk size and batch size. So the
           // chunk data is written to the cache one by one. Only the current
           // batch is retrieved, the next chunk is writen. Now after the first
-          // batch is retrieved, when we tries to retrive the second batch, there are three possible scenarios for the
-          // writer thread:
+          // batch is retrieved, when we tries to retrive the second batch,
+          // there are three possible scenarios for the writer thread:
           // 1. it hasn't started loading the next chunk data yet, so the
           // sequential sampler index is still 0;
           // 2. it started to load the second chunk, so the sequencial sampler
@@ -2015,7 +2015,8 @@ TEST(DataLoaderTest, ChunkDatasetSaveOption) {
           // window of [0, 3].
           // This analysis applies to all scenarios. So extend it to a more
           // general case: the expected saved index should falling into the
-          // range of [iteration - 1, iteration + 2], which is the validation below.
+          // range of [iteration - 1, iteration + 2], which is the validation
+          // below.
           ASSERT_TRUE(
               new_sampler.index() >= std::max(0, iteration_count - 1) &&
               new_sampler.index() <= iteration_count + 2);

--- a/test/cpp/api/dataloader.cpp
+++ b/test/cpp/api/dataloader.cpp
@@ -8,6 +8,7 @@
 #include <test/cpp/api/support.h>
 
 #include <c10/util/ArrayRef.h>
+#include <c10/util/tempfile.h>
 
 #include <algorithm>
 #include <chrono>
@@ -98,7 +99,10 @@ TEST(DataTest, ChunkDataSetWithInvalidInitParameter) {
   samplers::SequentialSampler sampler(0);
 
   auto initialization_function =
-      [&](size_t preloader_count, size_t batch_size, size_t cache_size) {
+      [&](size_t preloader_count,
+          size_t batch_size,
+          size_t cache_size,
+          std::string checkpoint_file_name = "") {
         datasets::SharedBatchDataset<datasets::ChunkDataset<
             DummyChunkDataReader,
             samplers::SequentialSampler,
@@ -111,7 +115,10 @@ TEST(DataTest, ChunkDataSetWithInvalidInitParameter) {
                 sampler,
                 sampler,
                 datasets::ChunkDatasetOptions(
-                    preloader_count, batch_size, cache_size));
+                    preloader_count,
+                    batch_size,
+                    cache_size,
+                    checkpoint_file_name));
       };
 
   ASSERT_THROWS_WITH(
@@ -1465,6 +1472,7 @@ TEST(DataLoaderTest, StatefulDatasetWithNoWorkers) {
     void reset() override {
       counter = 0;
     }
+    void save(const std::string& save_file_name) override{};
     int counter = 0;
   };
 
@@ -1501,6 +1509,8 @@ TEST(DataLoaderTest, StatefulDatasetWithManyWorkers) {
     void reset() override {
       counter = 0;
     }
+    void save(const std::string& save_file_name) override{};
+
     int counter = 0;
     std::mutex mutex;
   };
@@ -1538,6 +1548,7 @@ TEST(DataLoaderTest, StatefulDatasetWithMap) {
     void reset() override {
       counter = 0;
     }
+    void save(const std::string& save_file_name) override{};
     int counter = 0;
   };
 
@@ -1585,6 +1596,7 @@ TEST(DataLoaderTest, StatefulDatasetWithCollate) {
     void reset() override {
       counter = 0;
     }
+    void save(const std::string& save_file_name) override{};
     int counter = 0;
   };
 
@@ -1880,4 +1892,190 @@ TEST(DataLoaderTest, ChunkDatasetDoesNotHang) {
   // to fill the batch buffer but it is not draining. Still we need to exit
   // cleanly.
   auto iterator = data_loader->begin();
+}
+
+TEST(DataLoaderTest, ChunkDatasetSave) {
+  const size_t chunk_count_ = 6;
+  const size_t chunk_size = 10;
+
+  struct DummyTestChunkDataReader : datasets::ChunkDataReader<int> {
+   public:
+    using BatchType = datasets::ChunkDataReader<int>::ChunkType;
+
+    BatchType read_chunk(size_t chunk_index) override {
+      return batch_data_;
+    }
+
+    size_t chunk_count() override {
+      return chunk_count_;
+    };
+
+    void reset() override{};
+    BatchType batch_data_ = BatchType(chunk_size, 0);
+  };
+
+  const size_t prefetch_count = 1;
+  const size_t batch_size = chunk_size;
+  const size_t dataloader_worker_count = 0;
+  samplers::SequentialSampler sampler(0);
+  const int epoch_count = 2;
+
+  DummyTestChunkDataReader data_reader;
+
+  // tested save_intervals
+  const size_t save_intervals[] = {1, 2};
+
+  using datasets::ChunkDatasetOptions;
+
+  for (auto save_interval : save_intervals) {
+    auto tempfile = c10::make_tempfile();
+
+    datasets::SharedBatchDataset<datasets::ChunkDataset<
+        DummyTestChunkDataReader,
+        samplers::SequentialSampler,
+        samplers::SequentialSampler>>
+        dataset = datasets::make_shared_dataset<datasets::ChunkDataset<
+            DummyTestChunkDataReader,
+            samplers::SequentialSampler,
+            samplers::SequentialSampler>>(
+            data_reader,
+            sampler,
+            sampler,
+            ChunkDatasetOptions(
+                prefetch_count,
+                batch_size,
+                chunk_size /*cache size*/));
+
+    auto data_loader = torch::data::make_data_loader(
+        dataset,
+        DataLoaderOptions(batch_size).workers(dataloader_worker_count));
+
+    for (int epoch_index = 0; epoch_index < epoch_count; ++epoch_index) {
+      int iteration_count = 0;
+      for (auto iterator = data_loader->begin(); iterator != data_loader->end();
+           ++iterator, ++iteration_count) {
+             
+        if ((iteration_count + 1) % save_interval == 0) {
+          dataset->save(tempfile.name);
+
+          samplers::SequentialSampler new_sampler(0);
+          torch::load(new_sampler, tempfile.name);
+
+          // Verify save logic. For ChunkDataset, the chunk data is stored in a
+          // cache inside the dataset. One pool of threads are constantly
+          // writing to the cache, and a different pool of thread are constantly
+          // reading from the cache. Due to the nature of asynchronization, at
+          // the time of get_batch(), which chunk is written to the cache is not
+          // fully deterministic.
+          // But we can still calculate a restricted window on the expected
+          // output, hence verify the logic. In this test, the cache size is
+          // configured to be the same as chunk size and batch size. So the
+          // chunk data is written to the cache one by one. Only the current
+          // batch is retrieved, the next chunk is writen. Now after the first
+          // batch is retrieved, when we tries to retrive the second batch,
+          // there are three possible scenarios for the writer thread:
+          // 1. it hasn't started loading the next chunk data yet, so the
+          // sequential sampler index is still 0;
+          // 2. it started to load the second chunk, so the sequencial sampler
+          // index is at 1;
+          // 3. it finished loading the second chunk, and start to load the
+          // third chunk, because the cache is still fully occupied by the data
+          // from the second chunk, it is waiting to write to the cache. At this
+          // point, the sampler index is at 2.
+          // So now we have a window of [0, 2], which is what we expected the
+          // sampler to save the index from. Now noted for sequential sampler,
+          // it advances to the next index automatically in the call next(). So
+          // when save the index, it saves the next index in stead of the
+          // current one. In other word, after getting the first index from
+          // sequential sampler, it already moves to the second index. So when
+          // we save it, it is the second index we save. As a result,
+          // we need to advance the window by one. Now we have the expected
+          // window of [0, 3].
+          // This analysis applies to all scenarios. So extend it to a more
+          // general case: the expected saved index should falling into the
+          // range of [iteration - 1, iteration + 2], which is the validation
+          // below.
+          ASSERT_TRUE(
+              new_sampler.index() >= std::max(0, iteration_count - 1) &&
+              new_sampler.index() <= iteration_count + 2);
+        }
+      }
+    }
+  }
+}
+
+TEST(DataLoaderTest, ChunkDatasetResume) {
+  auto tempfile = c10::make_tempfile();
+
+  const size_t prefetch_count = 1;
+  const size_t batch_size = 10;
+  const size_t dataloader_worker_count = 0;
+  const size_t save_interval = 2;
+
+  DummyChunkDataReader data_reader;
+  samplers::SequentialSampler sampler(0);
+
+  const size_t skipped_chunk = 2;
+
+  // Configure sampler to skip 2 chunks
+  {
+    sampler.reset(data_reader.chunk_count());
+    sampler.next(skipped_chunk);
+    torch::save(sampler, tempfile.name);
+  }
+
+  // test functionality across epoch boundary. The first epoch should be
+  // affected by the checkpoint, but the second should start normally.
+  const int epoch_count = 2;
+
+  datasets::SharedBatchDataset<datasets::ChunkDataset<
+      DummyChunkDataReader,
+      samplers::SequentialSampler,
+      samplers::SequentialSampler>>
+      dataset = datasets::make_shared_dataset<datasets::ChunkDataset<
+          DummyChunkDataReader,
+          samplers::SequentialSampler,
+          samplers::SequentialSampler>>(
+          data_reader,
+          sampler,
+          sampler,
+          datasets::ChunkDatasetOptions(
+              prefetch_count,
+              batch_size,
+              20 /*cache size*/,
+
+              tempfile.name));
+
+  auto data_loader = torch::data::make_data_loader(
+      dataset, DataLoaderOptions(batch_size).workers(dataloader_worker_count));
+
+  for (int epoch_index = 0; epoch_index < epoch_count; ++epoch_index) {
+    int iteration_count = 0;
+
+    // For the first epoch, the returned batch should be returned from the
+    // third chunk, because the check point skipped the first two chunks. But
+    // for the next epoch, it should start from the first batch.
+    int initial_value = epoch_index == 0 ? 15 : 0;
+
+    for (auto iterator = data_loader->begin(); iterator != data_loader->end();
+         ++iterator, ++iteration_count) {
+      DummyChunkDataReader::BatchType batch = *iterator;
+
+      std::vector<int> expected_result;
+      size_t expected_size = (epoch_index > 0 && iteration_count == 3) ? 5 : 10;
+      expected_result.resize(expected_size);
+      std::iota(expected_result.begin(), expected_result.end(), initial_value);
+
+      ASSERT_EQ(batch.size(), expected_result.size());
+      ASSERT_TRUE(
+          std::equal(batch.begin(), batch.end(), expected_result.begin()));
+
+      initial_value += batch_size;
+    }
+  }
+
+  samplers::SequentialSampler new_sampler(0);
+  torch::load(new_sampler, tempfile.name);
+
+  ASSERT_EQ(new_sampler.index(), skipped_chunk);
 }

--- a/torch/csrc/api/include/torch/data/datasets/chunk.h
+++ b/torch/csrc/api/include/torch/data/datasets/chunk.h
@@ -274,9 +274,13 @@ struct ChunkDatasetOptions {
   /// The size of each batch.
   TORCH_ARG(size_t, batch_size);
 
-  // the capacity of the queue for batch caching.
+  /// The capacity of the queue for batch caching.
   TORCH_ARG(size_t, cache_size) = 2048;
 
+  /// The file name from where to load ChunkDatset's state. Default to empty
+  /// string meaning start ChunkDataset from fresh begining; when specified with
+  /// a file name, ChunkDataset::reset() will try to load the sampler state from
+  /// that file.
   TORCH_ARG(std::string, resume_from_file) = "";
 };
 
@@ -343,7 +347,7 @@ class ChunkDataset final
     return batch_buffer_->get_batch();
   }
 
-  void save(const std::string& save_file_name){
+  void save(const std::string& save_file_name) override {
     std::lock_guard<std::mutex> lock(chunk_index_guard_);
     torch::save(this->chunk_sampler(), save_file_name);
   }

--- a/torch/csrc/api/include/torch/data/datasets/stateful.h
+++ b/torch/csrc/api/include/torch/data/datasets/stateful.h
@@ -30,6 +30,9 @@ class StatefulDataset
  public:
   /// Resets internal state of the dataset.
   virtual void reset() = 0;
+
+  /// Saves the dataset's state to file.
+  virtual void save(const std::string& save_file_name) = 0;
 };
 } // namespace datasets
 } // namespace data

--- a/torch/csrc/api/include/torch/data/datasets/stateful.h
+++ b/torch/csrc/api/include/torch/data/datasets/stateful.h
@@ -31,9 +31,31 @@ class StatefulDataset
   /// Resets internal state of the dataset.
   virtual void reset() = 0;
 
-  /// Saves the dataset's state to file.
-  virtual void save(const std::string& save_file_name) = 0;
+  /// Saves the statefulDataset's state to OutputArchive.
+  virtual void save(serialize::OutputArchive& archive) const = 0;
+
+  /// Deserializes the statefulDataset's state from the `archive`.
+  virtual void load(serialize::InputArchive& archive) = 0;
 };
+
+/// Serializes a statefulDataset to `OutputArchive`.
+template <typename... Args>
+serialize::OutputArchive& operator<<(
+    serialize::OutputArchive& archive,
+    const StatefulDataset<Args...>& statefulDataset) {
+  statefulDataset.save(archive);
+  return archive;
+}
+
+/// Deserializes a statefulDataset from an `InputArchive`.
+template <typename... Args>
+serialize::InputArchive& operator>>(
+    serialize::InputArchive& archive,
+    StatefulDataset<Args...>& statefulDataset) {
+  statefulDataset.load(archive);
+  return archive;
+}
+
 } // namespace datasets
 } // namespace data
 } // namespace torch


### PR DESCRIPTION
This change adds support for checkpoint save/load logic in ChunkDataset.

The user can specify different action through CheckpointOption according to their need:

None: no checkpoint action needed;
Save: need to save checkpoint.
Load_Then_Save: need to load from a checkpoint and then save later status.
Load_Then_None: need to load from a checkpoint and then proceed without further action
For 'Save', 'Load_Then_Save', 'Load_Then_None', the user also need to supply a file name which we save/load the checkpoint to/from.
For 'Save' and 'Load_Then_Save', user need to specify save_inteval value, which indicates after how many minibatches, we conduct a save.